### PR TITLE
I remember why I ignored the decode error

### DIFF
--- a/items.go
+++ b/items.go
@@ -43,7 +43,7 @@ func (i *Item) Position() uint16 {
 // Attribute is the attribute of an item
 type Attribute struct {
 	Defindex    uint32
-	Value       int
+	Value       interface{}  `json:"value"`
 	FloatValue  float64      `json:"float_value,omitempty"`
 	AccountInfo *AccountInfo `json:",omitempty"`
 }

--- a/items_mock_test.go
+++ b/items_mock_test.go
@@ -22,7 +22,7 @@ func GetMockOKGetPlayerItems() string {
 								"class": 23,
 								"slot": 6
 							}
-						]				
+						]
 					},
 					{
 						"id": 1234567897,
@@ -37,11 +37,15 @@ func GetMockOKGetPlayerItems() string {
 				              "defindex": 8,
 				              "value": 1049511890,
 				              "float_value": 0.27789169549942017
-				            }
+				            },
+							{
+								"defindex": 147,
+								"value": "models/weapons/stattrack.mdl"
+							}
 			            ]
 					}
 				]
-				
+
 			}
 		}
 	`

--- a/items_test.go
+++ b/items_test.go
@@ -66,6 +66,11 @@ func TestMockOkGetPlayerItems(t *testing.T) {
 						FloatValue:  0.27789169549942017,
 						AccountInfo: (*AccountInfo)(nil),
 					},
+					Attribute{
+						Defindex:    9,
+						FloatValue:  0.2,
+						AccountInfo: (*AccountInfo)(nil),
+					},
 				},
 			},
 		},


### PR DESCRIPTION
Attribute values are not always int, generating an error.
Ignoring the error just make things simple, but not ideal.
I went one step further and turned it into an interface.

If you have a better idea, let me know!
