### PR TITLE
Don't parse invalid IDs

### DIFF
--- a/id.go
+++ b/id.go
@@ -44,6 +44,7 @@ func NewIdFromString(s string) (id steamId, err error) {
 
 	if !validid.MatchString(s) {
 		err = ErrInvalidId
+		return
 	}
 
 	tmp := strings.Split(s, ":")


### PR DESCRIPTION
Immediately return if the passed string ID is invalid or else a panic occurs while trying to parse it